### PR TITLE
fix build constraint position

### DIFF
--- a/pass_unix.go
+++ b/pass_unix.go
@@ -1,6 +1,6 @@
-package passwd
-
 // +build darwin linux
+
+package passwd
 
 import (
 	"bufio"


### PR DESCRIPTION
In Go files a build constraint must appear before the package clause. See https://golang.org/pkg/go/build/#hdr-Build_Constraints